### PR TITLE
Changed env variable from logstash version to 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian
 
 ENV VERIFIER_VERSION 1.6.3
-ENV LOGSTASH_VERSION 8
+ENV LOGSTASH_VERSION 7
 
 # Add unstable repo before updating, since openjdk-11-jre no longer exists in stable repo.
 RUN echo "deb http://deb.debian.org/debian unstable main non-free contrib" | tee -a /etc/apt/sources.list.d/java.list


### PR DESCRIPTION
Changed ENV variable in Dockerfile from 8 to 7, so that the logstash version is 7.17 (latest 7.x version).